### PR TITLE
Fix bad case for DeleteNodeGroup

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -96,7 +96,7 @@
       "Sid": "ResEKS",
       "Effect": "Allow",
       "Action": [
-        "eks:DeleteNodeGroup"
+        "eks:DeleteNode*"
       ],
       "Resource": [
         "arn:${partition}:eks:${region}:${account_id}:nodegroup/*/${nodepool_pattern}/*"
@@ -314,7 +314,7 @@
       ],
       "Resource": [
         "arn:${partition}:iam::${account_id}:role/StreamNative/*",
-        "arn:${partition}:iam::${account_id}:role/${cluster_pattern}" 
+        "arn:${partition}:iam::${account_id}:role/${cluster_pattern}"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
The iam action for EKS is not DeleteNodeGroup but DeleteNodegroup

In order to just remove this, instead just convert this to a wildcard