### PR TITLE
fix: add iam:CreatePolicy

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -296,6 +296,7 @@
         "iam:TagRole",
         "iam:TagInstanceProfile",
         "iam:TagOpenIDConnectProvider",
+        "iam:CreatePolicy",
         "iam:DeletePolicy",
         "iam:DeletePolicyVersion"
       ],

--- a/modules/aws/files/permission_boundary_iam_policy.json.tpl
+++ b/modules/aws/files/permission_boundary_iam_policy.json.tpl
@@ -45,6 +45,7 @@
       "Sid": "IamRestrictions",
       "Effect": "Allow",
       "Action": [
+        "iam:CreatePolicy",
         "iam:AddRoleToInstanceProfile",
         "iam:CreateOpenIDConnectProvider",
         "iam:CreateServiceLinkedRole",


### PR DESCRIPTION
### Motivation
The [terraform-aws-cloud](https://github.com/streamnative/terraform-aws-cloud/blob/0e400642f61318d36f6a3c9de8b1c7a225fc3470/aws_load_balancer_controller.tf#L266) requires iam:CreatePolicy permission to create IAM Policy.