### PR TITLE
Update policy versions and prepare for release

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -14,7 +14,8 @@
         "route53:ChangeTagsForResource",
         "support:*",
         "servicequotas:List*",
-        "servicequotas:Get*"
+        "servicequotas:Get*",
+        "sts:DecodeAuthorizationMessage"
       ],
       "Resource": "*"
     },

--- a/modules/aws/files/management_role_iam_policy.json.tpl
+++ b/modules/aws/files/management_role_iam_policy.json.tpl
@@ -25,7 +25,8 @@
         "route53:List*",
         "support:*",
         "servicequotas:List*",
-        "servicequotas:Get*"
+        "servicequotas:Get*",
+        "sts:DecodeAuthorizationMessage"
       ],
       "Resource": "*"
     },

--- a/modules/aws/files/runtime_iam_policy.json.tpl
+++ b/modules/aws/files/runtime_iam_policy.json.tpl
@@ -27,7 +27,7 @@
             "Effect": "Allow",
             "Action": [
                 "route53:ChangeResourceRecordSets",
-                "route53:ListResourceRecordSets" 
+                "route53:ListResourceRecordSets"
             ],
             "Resource": ${r53_zone_arns}
         },
@@ -54,7 +54,7 @@
                 "kms:ListGrants",
                 "kms:CreateGrant"
             ],
-            "Resource": [ ${kms_arns} ],  
+            "Resource": [ ${kms_arns} ],
             "Condition": {
                 "Bool": {
                     "kms:GrantIsForAWSResource": [
@@ -73,7 +73,7 @@
                 "kms:DescribeKey",
                 "kms:Decrypt"
             ],
-            "Resource": [ ${kms_arns} ]  
+            "Resource": [ ${kms_arns} ]
         },
         {
             "Sid": "s3b",
@@ -93,7 +93,7 @@
                 "s3:*Object",
                 "s3:*Multipart*"
             ],
-            "Resource": "arn:aws:s3:::${bucket_pattern}"  
+            "Resource": "arn:aws:s3:::${bucket_pattern}"
         },
         {
             "Sid": "vbc",
@@ -102,12 +102,20 @@
                 "ec2:CreateVolume",
                 "ec2:CreateSnapshot"
             ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "vbcd",
+            "Effect": "Deny",
+            "Action": [
+                "ec2:CreateVolume",
+                "ec2:CreateSnapshot"
+            ],
             "Resource": "*",
             "Condition": {
-                "StringLike": {
-                    "aws:RequestTag/kubernetes.io/cluster/${cluster_pattern}": [
-                        "owned"
-                    ]
+                "StringNotLike": {
+                    "aws:ResourceTag/Vendor": "StreamNative",
+                    "aws:Type": "snapshot"
                 }
             }
         },
@@ -135,8 +143,8 @@
             "Resource": "*",
             "Condition": {
                 "StringLike": {
-                    "aws:ResourceTag/kubernetes.io/cluster/${cluster_pattern}": [
-                        "owned"
+                    "aws:ResourceTag/Vendor": [
+                        "StreamNative"
                     ]
                 }
             }

--- a/modules/aws/variables.tf
+++ b/modules/aws/variables.tf
@@ -69,7 +69,7 @@ variable "s3_bucket_pattern" {
 }
 
 variable "sn_policy_version" {
-  default     = "3.0.0"
+  default     = "3.1.0"
   description = "The value of SNVersion tag"
   type        = string
 }


### PR DESCRIPTION
This commit updates the runtime policy to support more consistent support of snapshot creation for the purposes of backups.

Additionally, it adds some additional call to aid in debugging.

This also bumps the version to prepare for a release