### PR TITLE
Whitelist more roles we can attach

### DIFF
--- a/modules/aws/main.tf
+++ b/modules/aws/main.tf
@@ -58,12 +58,9 @@ locals {
 
   default_allowed_iam_policies = compact([
     "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/*",
-    "arn:${local.aws_partition}:iam::aws:policy/AmazonEKSClusterPolicy",
-    "arn:${local.aws_partition}:iam::aws:policy/AmazonEKSServicePolicy",
-    "arn:${local.aws_partition}:iam::aws:policy/AmazonEKSVPCResourceController",
-    "arn:${local.aws_partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-    "arn:${local.aws_partition}:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:${local.aws_partition}:iam::aws:policy/AmazonEKS*",
     "arn:${local.aws_partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:${local.aws_partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
     "arn:${local.aws_partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
   ])
 }


### PR DESCRIPTION
This commit whitelists a few more roles and simplifies the role list to be a wildcard

Rather than explictily list each EKS role, we instead use a wildcard.

This grants us access to use Fargate role (otherwise we already had listed each role) and then also adds SSM which we can use in the future