### PR TITLE
Don't deny createVolume

### DIFF
--- a/modules/aws/files/runtime_iam_policy.json.tpl
+++ b/modules/aws/files/runtime_iam_policy.json.tpl
@@ -108,7 +108,6 @@
             "Sid": "vbcd",
             "Effect": "Deny",
             "Action": [
-                "ec2:CreateVolume",
                 "ec2:CreateSnapshot"
             ],
             "Resource": "*",

--- a/modules/aws/variables.tf
+++ b/modules/aws/variables.tf
@@ -69,7 +69,7 @@ variable "s3_bucket_pattern" {
 }
 
 variable "sn_policy_version" {
-  default     = "3.1.0"
+  default     = "3.1.1"
   description = "The value of SNVersion tag"
   type        = string
 }


### PR DESCRIPTION
In #21, the policy was updated to fix snapshots, but erroneously, an extra deny was added for CreateVolume

This fixes that and bumps the version