### PR TITLE
Fix aws lb iam policy

### DIFF
--- a/modules/aws/files/aws_lb_controller_iam_policy.json.tpl
+++ b/modules/aws/files/aws_lb_controller_iam_policy.json.tpl
@@ -207,6 +207,28 @@
         {
             "Effect": "Allow",
             "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:${partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:${partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:${partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "elasticloadbalancing:RegisterTargets",
                 "elasticloadbalancing:DeregisterTargets"
             ],


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2692#issuecomment-1602615427
Diff:
```bash
diff <(sed 's/${partition}/aws/' terraform-managed-cloud/modules/aws/files/aws_lb_controller_iam_policy.json.tpl) iam_policy.json
74,79c74
<             "Resource": "*",
<             "Condition": {
<                 "StringEquals": {
<                     "aws:ResourceTag/Vendor": "StreamNative"
<                  }
<             }
---
>             "Resource": "*"
128,131c123
<                 },
<                 "StringEquals": {
<                     "aws:ResourceTag/Vendor": "StreamNative"
<                  }
---
>                 }
```
