### PR TITLE
feat: add ec2:AttachVolume to bootstrap policy

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -208,6 +208,7 @@
         "autoscaling:SetDesired*",
         "ec2:AssignPrivateIpAddresses",
         "ec2:AttachInternetGateway",
+        "ec2:AttachVolume",
         "ec2:CreateLaunchTemplateVersion",
         "ec2:CreateNatGateway",
         "ec2:CreateNetworkInterface",


### PR DESCRIPTION
### Motivation
For using old existing data volumes, to rebuild or migrate.