### PR TITLE
feat: Support create private service endpoint on shared VPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ terraform.rc
 .DS_Store
 .vscode/
 .idea/
+tests

--- a/examples/gcp/private-service/main.tf
+++ b/examples/gcp/private-service/main.tf
@@ -1,6 +1,7 @@
 locals {
-  region     = "us-east1"
-  project_id = "<your-project-name>"
+  region             = "us-east1"
+  project_id         = "<your-project-name>"
+  network_project_id = "<your-network-project-name>"
 }
 
 provider "google" {
@@ -14,6 +15,7 @@ module "gcp-private-service-core" {
   source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.3.1"
 
   region              = local.region
+  project             = local.project_id
   network_name        = "default"
   subnet_name         = "default"
   domain_name         = "gcp-use1-prod-snc.o-xxxx.g.snio.cloud"
@@ -25,14 +27,31 @@ module "gcp-private-service-core" {
 
 # Expose Private Pulsar Service to region us-east1 in network svc2
 module "gcp-private-service-svc2" {
-  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.3.1"
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.4.1"
 
-  region             = local.region
-  network_name       = "svc2"
-  subnet_name        = "svc2"
+  region              = local.region
+  project             = local.project_id
+  network_name        = "svc2"
+  subnet_name         = "svc2"
   domain_name         = "gcp-use1-prod-snc.o-xxxx.g.snio.cloud"
-  service_attachment = "projects/<pulsar-project-name>/regions/us-east1/serviceAttachments/pulsar-private-service"
+  service_attachment  = "projects/<pulsar-project-name>/regions/us-east1/serviceAttachments/pulsar-private-service"
   cross_region_access = false
-  suffix             = "svc2"
+  suffix              = "svc2"
+}
+
+
+# Expose Private Pulsar Service to shared VPC shared in project <your-network-project-name>
+module "gcp-private-service-shared" {
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.4.1"
+
+  region              = local.region
+  project             = local.project_id
+  network_project     = local.network_project_id
+  network_name        = "shared"
+  subnet_name         = "shared"
+  domain_name         = "gcp-use1-prod-snc.o-xxxx.g.snio.cloud"
+  service_attachment  = "projects/<pulsar-project-name>/regions/us-east1/serviceAttachments/pulsar-private-service"
+  cross_region_access = false
+  suffix              = "shared"
 }
 

--- a/examples/gcp/private-service/main.tf
+++ b/examples/gcp/private-service/main.tf
@@ -12,7 +12,7 @@ provider "google" {
 
 # Expose Private Pulsar Service to all regions in network default
 module "gcp-private-service-core" {
-  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.3.1"
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.5.0"
 
   region              = local.region
   project             = local.project_id
@@ -27,7 +27,7 @@ module "gcp-private-service-core" {
 
 # Expose Private Pulsar Service to region us-east1 in network svc2
 module "gcp-private-service-svc2" {
-  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.4.1"
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.5.0"
 
   region              = local.region
   project             = local.project_id
@@ -42,7 +42,7 @@ module "gcp-private-service-svc2" {
 
 # Expose Private Pulsar Service to shared VPC shared in project <your-network-project-name>
 module "gcp-private-service-shared" {
-  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.4.1"
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.5.0"
 
   region              = local.region
   project             = local.project_id

--- a/modules/gcp/private-service/common.tf
+++ b/modules/gcp/private-service/common.tf
@@ -3,6 +3,17 @@ variable "region" {
   description = "The GCP region where the private service connection will be configured."
 }
 
+variable "project" {
+  type = string
+  description = "The GCP project where the private service connection will be configured."
+}
+
+variable "network_project" {
+  type = string
+  description = "The GCP project where the shared VPC located in."
+  default = ""
+}
+
 variable "network_name" {
   type = string
   description = "The GCP network where the private service connection will be available."

--- a/modules/gcp/private-service/main.tf
+++ b/modules/gcp/private-service/main.tf
@@ -1,15 +1,18 @@
 locals {
-  dns_name = "${var.domain_name}."
+  dns_name        = "${var.domain_name}."
+  network_project = var.network_project != "" ? var.network_project : var.project
 }
 
 
 data "google_compute_network" "network" {
-  name = var.network_name
+  name    = var.network_name
+  project = local.network_project
 }
 
 data "google_compute_subnetwork" "subnet" {
-  name   = var.subnet_name
-  region = var.region
+  name    = var.subnet_name
+  region  = var.region
+  project = local.network_project
 }
 
 resource "google_compute_address" "psc_endpoint_address" {
@@ -17,12 +20,14 @@ resource "google_compute_address" "psc_endpoint_address" {
   region       = var.region
   subnetwork   = data.google_compute_subnetwork.subnet.id
   address_type = "INTERNAL"
+  project      = local.network_project
 }
 
 
 resource "google_dns_managed_zone" "psc_endpoint_zone" {
   name       = "pulsar-psc-${var.suffix}"
   dns_name   = local.dns_name
+  project    = var.project
   visibility = "private"
   private_visibility_config {
     networks {
@@ -37,6 +42,7 @@ resource "google_dns_record_set" "wildcard_endpoint" {
   type         = "A"
   ttl          = 300
   rrdatas      = [google_compute_address.psc_endpoint_address.address]
+  project      = var.project
 }
 
 
@@ -48,4 +54,13 @@ resource "google_compute_forwarding_rule" "psc_endpoint" {
   target                  = var.service_attachment
   network                 = data.google_compute_network.network.id
   ip_address              = google_compute_address.psc_endpoint_address.id
+  project                 = var.project
+}
+
+output "network_id" {
+  value = data.google_compute_network.network.id
+}
+
+output "endpoint_address" {
+  value = google_compute_address.psc_endpoint_address.id
 }


### PR DESCRIPTION
```hcl
# Expose Private Pulsar Service to shared VPC shared in project <network-project>
module "gcp-private-service-shared" {
  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.5.0"

  region              = "us-east1"
  project             = "<service-project>"
  network_project     = "<network-project>"
  network_name        = "shared"
  subnet_name         = "shared"
  domain_name         = "gcp-use1-prod-snc.o-xxxx.g.snio.cloud"
  service_attachment  = "projects/<pulsar-project-name>/regions/us-east1/serviceAttachments/pulsar-private-service"
  cross_region_access = false
  suffix              = "shared"
}
```