### PR TITLE
feat: add iam policy for aws vpc peering

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -256,6 +256,14 @@
       "Resource": "*"
     },
     {
+      "Sid": "EndpointConnectionAccess",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:*VpcEndpointConnections"
+      ],
+      "Resource": "*"
+    }
+    {
       "Sid": "SSMStop",
       "Effect": "Allow",
       "Action": [

--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -218,6 +218,9 @@
         "ec2:CreateSubnet",
         "ec2:CreateTags",
         "ec2:CreateVpcEndpoint",
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:CreateVpcPeeringConnection",
+        "ec2:DeleteVpcPeeringConnection",
         "ec2:Detach*",
         "ec2:Release*",
         "ec2:Revoke*",
@@ -243,6 +246,14 @@
           "aws:ResourceTag/Vendor": "StreamNative"
         }
       }
+    },
+    {
+      "Sid": "AcceptVpcPeering",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AcceptVpcPeeringConnection"
+      ],
+      "Resource": "*"
     },
     {
       "Sid": "SSMStop",

--- a/modules/aws/variables.tf
+++ b/modules/aws/variables.tf
@@ -16,7 +16,7 @@
 
 variable "sn_policy_version" {
   description = "The value of SNVersion tag"
-  default     = "3.4.0"    # x-release-please-version
+  default     = "3.6.0"    # x-release-please-version
   type        = string
 }
 


### PR DESCRIPTION
Note: Remove the condition check for the `Vendor` tag for `AcceptVpcPeering` action, as the accepter PeeringConnection created by AWS automatically won't have any tags.