### PR TITLE
feat: add gcp dns-zone module

### DIFF
--- a/modules/gcp/dns-zone/README.md
+++ b/modules/gcp/dns-zone/README.md
@@ -1,0 +1,58 @@
+# DNS Zone Module
+
+To create a new zone in the target project and then create the delegations in the source project.
+
+## Quickstart
+
+```hcl
+module "gcp-dns-zone" {
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/dns-zone"
+
+  source_project = "<input-project-holds-source-zone>"
+  target_project = "<input-project-holds-target-zone>"
+
+  source_zone_name     = "<input-source-zone>"
+  target_zone_name     = "<input-target-zone>"
+  target_zone_dns_name = "<input-target-dns>"
+}
+```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google.source"></a> [google.source](#provider\_google.source) | n/a |
+| <a name="provider_google.target"></a> [google.target](#provider\_google.target) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_dns_managed_zone.target](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
+| [google_dns_record_set.delegate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_dns_managed_zone.source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_source_project"></a> [source\_project](#input\_source\_project) | The gcp project which holds the parent zone | `string` | n/a | yes |
+| <a name="input_source_zone_name"></a> [source\_zone\_name](#input\_source\_zone\_name) | The parent zone in which create the delegation records | `string` | n/a | yes |
+| <a name="input_target_project"></a> [target\_project](#input\_target\_project) | The gcp project which holds the new zone | `string` | n/a | yes |
+| <a name="input_target_zone_dns_name"></a> [target\_zone\_dns\_name](#input\_target\_zone\_dns\_name) | The new DNS name | `string` | n/a | yes |
+| <a name="input_target_zone_name"></a> [target\_zone\_name](#input\_target\_zone\_name) | The new zone name | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/gcp/dns-zone/main.tf
+++ b/modules/gcp/dns-zone/main.tf
@@ -1,0 +1,34 @@
+provider "google" {
+  alias = "source"
+
+  project = var.source_project
+}
+
+provider "google" {
+  alias = "target"
+
+  project = var.target_project
+}
+
+resource "google_dns_managed_zone" "target" {
+  provider = google.target
+
+  name     = var.target_zone_name
+  dns_name = var.target_zone_dns_name
+}
+
+data "google_dns_managed_zone" "source" {
+  provider = google.source
+
+  name = var.source_zone_name
+}
+
+resource "google_dns_record_set" "delegate" {
+  provider = google.source
+
+  managed_zone = data.google_dns_managed_zone.source.name
+  name         = google_dns_managed_zone.target.dns_name
+  type         = "NS"
+  ttl          = "300"
+  rrdatas      = google_dns_managed_zone.target.name_servers
+}

--- a/modules/gcp/dns-zone/variables.tf
+++ b/modules/gcp/dns-zone/variables.tf
@@ -1,0 +1,29 @@
+variable "source_project" {
+  type        = string
+  description = "The gcp project which holds the parent zone"
+}
+
+variable "target_project" {
+  type        = string
+  description = "The gcp project which holds the new zone"
+}
+
+variable "source_zone_name" {
+  type        = string
+  description = "The parent zone in which create the delegation records"
+}
+
+variable "target_zone_name" {
+  type        = string
+  description = "The new zone name"
+}
+
+variable "target_zone_dns_name" {
+  type        = string
+  description = "The new DNS name"
+
+  validation {
+    condition     = endswith(var.target_zone_dns_name, ".")
+    error_message = "DNS name must end with '.'"
+  }
+}

--- a/modules/gcp/dns-zone/versions.tf
+++ b/modules/gcp/dns-zone/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=1.2.0"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation
To help customer configure new sub DNS zone.

## How to use?
```hcl
module "gcp-dns-zone" {
  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/dns-zone"

  source_project = "<input-project-holds-source-zone>"
  target_project = "<input-project-holds-target-zone>"

  source_zone_name     = "<input-source-zone>"
  target_zone_name     = "<input-target-zone>"
  target_zone_dns_name = "<input-target-dns>"
}
```