### PR TITLE
feat: update aws role session duration

### DIFF
--- a/modules/aws/main.tf
+++ b/modules/aws/main.tf
@@ -188,6 +188,7 @@ resource "aws_iam_role" "bootstrap_role" {
   path                 = "/StreamNative/"
   permissions_boundary = aws_iam_policy.permission_boundary.arn
   tags                 = local.tag_set
+  max_session_duration = 43200
 }
 
 resource "aws_iam_policy" "bootstrap_policy" {
@@ -245,6 +246,7 @@ resource "aws_iam_role" "management_role" {
   path                 = "/StreamNative/"
   permissions_boundary = aws_iam_policy.permission_boundary.arn
   tags                 = local.tag_set
+  max_session_duration = 43200
 }
 
 resource "aws_iam_role_policy_attachment" "management_role" {


### PR DESCRIPTION
### Motivation

Maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.

The default 1 hour is too short for debugging customer's issues.

Ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#max_session_duration