### PR TITLE
feat: Allow iam:PutRolePolicy and iam:DeleteRolePolicy in aws

### DIFF
--- a/modules/aws/files/management_role_iam_policy.json.tpl
+++ b/modules/aws/files/management_role_iam_policy.json.tpl
@@ -84,6 +84,8 @@
       "Action": [
         "iam:DeleteRole",
         "iam:DetachRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
         "iam:PutRolePermissionsBoundary",
         "iam:SetDefaultPolicyVersion",
         "iam:UpdateAssumeRolePolicy",

--- a/modules/aws/files/permission_boundary_iam_policy.json.tpl
+++ b/modules/aws/files/permission_boundary_iam_policy.json.tpl
@@ -4,7 +4,7 @@
     {
       "Sid": "AllowedServices",
       "Effect": "Allow",
-      "Action": [q
+      "Action": [
           "acm:*",
           "autoscaling:*",
           "cognito-idp:*",

--- a/modules/aws/files/permission_boundary_iam_policy.json.tpl
+++ b/modules/aws/files/permission_boundary_iam_policy.json.tpl
@@ -4,7 +4,7 @@
     {
       "Sid": "AllowedServices",
       "Effect": "Allow",
-      "Action": [
+      "Action": [q
           "acm:*",
           "autoscaling:*",
           "cognito-idp:*",
@@ -43,6 +43,7 @@
         "iam:DeleteServiceLinkedRole",
         "iam:DetachRolePolicy",
         "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
         "iam:PutRolePermissionsBoundary",
         "iam:RemoveRoleFromInstanceProfile",
         "iam:SetDefaultPolicyVersion",


### PR DESCRIPTION
Grant manager role `iam:PutRolePolicy` and `iam:DeleteRolePolicy` for configuring bucket read/write permission for broker