### PR TITLE
feat(aws): allow update route tables

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -215,6 +215,8 @@
         "ec2:CreateNetworkInterface",
         "ec2:CreateRoute",
         "ec2:CreateRouteTable",
+        "ec2:ReplaceRoute",
+        "ec2:ReplaceRouteTableAssociation",
         "ec2:CreateSecurityGroup",
         "ec2:CreateSubnet",
         "ec2:CreateTags",


### PR DESCRIPTION
## Motivation
To support https://github.com/streamnative/terraform-aws-cloud/pull/125

When apply with optimized route tables, we need `ec2:ReplaceRoute` and `ec2:ReplaceRouteTableAssociation` permission

## Modification

- Add `ec2:ReplaceRoute` and `ec2:ReplaceRouteTableAssociation` to bootstrap role