### PR TITLE
fix(aws): autoscaling condition key

### DIFF
--- a/modules/aws/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/aws/files/bootstrap_role_iam_policy.json.tpl
@@ -114,7 +114,7 @@
       "Resource": [ "*" ],
       "Condition": {
         "StringLike": {
-          "autoscaling:ResourceTag/cluster-name": "${cluster_pattern}"
+          "autoscaling:ResourceTag/eks:cluster-name": "${cluster_pattern}"
         }
       }
     },


### PR DESCRIPTION
## Motivation
The actual generated ASG tag key is `eks:cluster-name` rather than `cluster-name`.
Wrong condition will block autoscaling tagging operations.

The AWS didn't explicitly tell user about this, but here are some references:

- https://docs.aws.amazon.com/eks/latest/userguide/eks-using-tags.html
- https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group

## Modification

- Change condition key to `"autoscaling:ResourceTag/eks:cluster-name"`