### PR TITLE
fix: allow detach instance profile

### DIFF
--- a/modules/aws/vendor-access/files/provision2.json.tpl
+++ b/modules/aws/vendor-access/files/provision2.json.tpl
@@ -217,7 +217,8 @@
       "Resource": [
         "arn:${partition}:iam::${account_id}:role/StreamNative/*",
         "arn:${partition}:iam::${account_id}:policy/StreamNative/*",
-        "arn:${partition}:iam::${account_id}:oidc-provider/*"
+        "arn:${partition}:iam::${account_id}:oidc-provider/*",
+        "arn:${partition}:iam::${account_id}:instance-profile/*"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
## Motivation
Karpenter need manage the instance profile directly rather than managed node groups.

The role is managed here: https://github.com/streamnative/terraform-aws-cloud/blob/master/main.tf#L435