### PR TITLE
feat: Support creating separate PSC for each zone in GCP

### DIFF
--- a/examples/gcp/private-service/main.tf
+++ b/examples/gcp/private-service/main.tf
@@ -55,3 +55,30 @@ module "gcp-private-service-shared" {
   suffix              = "shared"
 }
 
+# Expose Topology Aware Private Pulsar Service to region us-east1 in network default
+
+module "gcp-private-service-topology-aware" {
+  source = "github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=v3.21.0"
+
+  region       = local.region
+  project      = local.project_id
+  network_name = "default"
+  subnet_name  = "default"
+  domain_name  = "gcp-use1-prod-snc.o-xxxx.g.snio.cloud"
+  service_attachments = [
+    {
+      zone = "us-east1-a",
+      id   = "projects/<pulsar-project>/regions/us-east1/serviceAttachments/istio-system-istio-ingressgateway-us-central1-a",
+    },
+    {
+      zone = "us-east1-b",
+      id   = "projects/<pulsar-project>/regions/us-east1/serviceAttachments/istio-system-istio-ingressgateway-us-central1-b",
+    },
+    {
+      zone = "us-east1-c",
+      id   = "projects/<pulsar-project>/regions/us-east1/serviceAttachments/istio-system-istio-ingressgateway-us-central1-c",
+    }
+  ]
+  cross_region_access = false
+  suffix              = "topology-aware"
+}

--- a/modules/gcp/private-service/common.tf
+++ b/modules/gcp/private-service/common.tf
@@ -1,45 +1,60 @@
 variable "region" {
-  type = string
+  type        = string
   description = "The GCP region where the private service connection will be configured."
 }
 
 variable "project" {
-  type = string
+  type        = string
   description = "The GCP project where the private service connection will be configured."
 }
 
 variable "network_project" {
-  type = string
+  type        = string
   description = "The GCP project where the shared VPC located in."
-  default = ""
+  default     = ""
 }
 
 variable "network_name" {
-  type = string
+  type        = string
   description = "The GCP network where the private service connection will be available."
 }
 
 variable "subnet_name" {
-  type = string
+  type        = string
   description = "The GCP subnet where the endpoint IP of private service connection will be allocated."
 }
 
 variable "domain_name" {
   type = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$", var.domain_name))
+    error_message = "The domain name must be a valid DNS name."
+  }
   description = "The base domain of private pulsar service."
 }
 
 variable "service_attachment" {
-  type = string
+  type        = string
+  default     = ""
   description = "The id of pulsar private service attachment."
 }
 
 variable "cross_region_access" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Allow access cross regions in the network."
 }
 
 variable "suffix" {
   description = "The suffix that will be part of the name of resources."
+}
+
+
+variable "service_attachments" {
+  type = list(object({
+    id   = string
+    zone = string
+  }))
+  default     = []
+  description = "The list of service attachments, only used when enable_topology_aware_gateway is true."
 }

--- a/modules/gcp/private-service/main.tf
+++ b/modules/gcp/private-service/main.tf
@@ -111,7 +111,7 @@ output "network_id" {
   value = data.google_compute_network.network.id
 }
 
-output "endpoint_address" {
+output "endpoint_addresses" {
   value = local.enable_topology_aware_gateway ? [
     for zone, id in local.service_attachments : google_compute_address.psc_endpoint_addresses[zone].address
   ] : [google_compute_address.psc_endpoint_address[0].address]

--- a/modules/gcp/private-service/main.tf
+++ b/modules/gcp/private-service/main.tf
@@ -1,6 +1,10 @@
 locals {
-  dns_name        = "${var.domain_name}."
-  network_project = var.network_project != "" ? var.network_project : var.project
+  dns_name                      = "${var.domain_name}."
+  network_project               = var.network_project != "" ? var.network_project : var.project
+  enable_topology_aware_gateway = length(var.service_attachments) > 0
+  service_attachments = {
+    for idx, sa in var.service_attachments : sa.zone => sa.id
+  }
 }
 
 
@@ -16,7 +20,17 @@ data "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_address" "psc_endpoint_address" {
+  count        = local.enable_topology_aware_gateway ? 0 : 1
   name         = "pulsar-psc-${var.suffix}"
+  region       = var.region
+  subnetwork   = data.google_compute_subnetwork.subnet.id
+  address_type = "INTERNAL"
+  project      = local.network_project
+}
+
+resource "google_compute_address" "psc_endpoint_addresses" {
+  for_each     = local.service_attachments
+  name         = "pulsar-psc-${var.suffix}-${each.key}"
   region       = var.region
   subnetwork   = data.google_compute_subnetwork.subnet.id
   address_type = "INTERNAL"
@@ -37,23 +51,59 @@ resource "google_dns_managed_zone" "psc_endpoint_zone" {
 }
 
 resource "google_dns_record_set" "wildcard_endpoint" {
+  count        = local.enable_topology_aware_gateway ? 0 : 1
   managed_zone = google_dns_managed_zone.psc_endpoint_zone.name
   name         = "*.${local.dns_name}"
   type         = "A"
   ttl          = 300
-  rrdatas      = [google_compute_address.psc_endpoint_address.address]
+  rrdatas      = [google_compute_address.psc_endpoint_address[0].address]
   project      = var.project
 }
 
 
+resource "google_dns_record_set" "zonal_wildcard_endpoint" {
+  count        = local.enable_topology_aware_gateway ? 1 : 0
+  managed_zone = google_dns_managed_zone.psc_endpoint_zone.name
+  name         = "*.${local.dns_name}"
+  type         = "A"
+  ttl          = 300
+  rrdatas = [
+    for zone, id in local.service_attachments : google_compute_address.psc_endpoint_addresses[zone].address
+  ]
+  project = var.project
+}
+
+resource "google_dns_record_set" "zonal_endpoint" {
+  for_each     = local.service_attachments
+  managed_zone = google_dns_managed_zone.psc_endpoint_zone.name
+  name         = "*.${each.key}.${local.dns_name}"
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_address.psc_endpoint_addresses[each.key].address]
+  project      = var.project
+}
+
 resource "google_compute_forwarding_rule" "psc_endpoint" {
+  count                   = local.enable_topology_aware_gateway ? 0 : 1
   name                    = "pulsar-psc-${var.suffix}"
   region                  = var.region
   load_balancing_scheme   = ""
   allow_psc_global_access = var.cross_region_access
   target                  = var.service_attachment
   network                 = data.google_compute_network.network.id
-  ip_address              = google_compute_address.psc_endpoint_address.id
+  ip_address              = google_compute_address.psc_endpoint_address[0].id
+  project                 = var.project
+}
+
+resource "google_compute_forwarding_rule" "zonal_psc_endpoint" {
+  for_each                = local.service_attachments
+  name                    = "pulsar-psc-${var.suffix}-${each.key}"
+  region                  = var.region
+  load_balancing_scheme   = ""
+  allow_psc_global_access = var.cross_region_access
+  target                  = each.value
+  network                 = data.google_compute_network.network.id
+  ip_address              = google_compute_address.psc_endpoint_addresses[each.key].id
   project                 = var.project
 }
 
@@ -62,5 +112,7 @@ output "network_id" {
 }
 
 output "endpoint_address" {
-  value = google_compute_address.psc_endpoint_address.id
+  value = local.enable_topology_aware_gateway ? [
+    for zone, id in local.service_attachments : google_compute_address.psc_endpoint_addresses[zone].address
+  ] : [google_compute_address.psc_endpoint_address[0].address]
 }


### PR DESCRIPTION
Usage example
```hcl
module "topology_aware_psc" {
  source = "git::https://github.com/streamnative/terraform-managed-cloud//modules/gcp/private-service?ref=main"

  domain_name  = "gcp-usc1-example.example.com"
  project      = "<your-client-gcp-project>"
  region       = "us-central1"
  network_name = "<your-client-network>"
  subnet_name  = "<your-client-subnet>"
  suffix       = "gcp-usc1-example"

  service_attachments = [
    {
      zone = "us-central1-a",
      id   = "projects/<pulsar-project>/regions/us-central1/serviceAttachments/istio-system-istio-ingressgateway-us-central1-a",
    },
    {
      zone = "us-central1-b",
      id   = "projects/<pulsar-project>/regions/us-central1/serviceAttachments/istio-system-istio-ingressgateway-us-central1-b",
    },
    {
      zone = "us-central1-c",
      id   = "projects/<pulsar-project>/regions/us-central1/serviceAttachments/istio-system-istio-ingressgateway-us-central1-c",
    }
  ]
}
```