### PR TITLE
fix: remove provider block in child module

### DIFF
--- a/modules/aws/private-link/main.tf
+++ b/modules/aws/private-link/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.region
-}
-
 data "aws_vpc" "this" {
   id = var.vpc_id
 }


### PR DESCRIPTION
## Motivation
The child module should not declare provider block, which will override the root module.