### PR TITLE
feat: Allow disabling local accounts permission

### DIFF
--- a/modules/azure/vendor-access/role-assignment-condition.tpl
+++ b/modules/azure/vendor-access/role-assignment-condition.tpl
@@ -4,7 +4,7 @@
  )
  OR 
  (
-  @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1, 4d97b98b-1d4f-4787-a291-c67834d212e7, befefa01-2a29-4197-83a8-272ff33ce314, acdd72a7-3385-48ef-bd42-f606fba81ae7, ba92f5b4-2d11-453d-a403-e96b0029c9fe, 0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8, 4abbcc35-e782-43d8-92c5-2d3f1bd2253f, acdd72a7-3385-48ef-bd42-f606fba81ae7, b7e6dc6d-f1e8-4753-8033-0f276bb0955b, 
+  @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1, 4d97b98b-1d4f-4787-a291-c67834d212e7, befefa01-2a29-4197-83a8-272ff33ce314, acdd72a7-3385-48ef-bd42-f606fba81ae7, ba92f5b4-2d11-453d-a403-e96b0029c9fe, 0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8, 4abbcc35-e782-43d8-92c5-2d3f1bd2253f, acdd72a7-3385-48ef-bd42-f606fba81ae7, b7e6dc6d-f1e8-4753-8033-0f276bb0955b, b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b,
   ${role_definition_id}}
   AND
   @Request[Microsoft.Authorization/roleAssignments:PrincipalType] ForAnyOfAnyValues:StringEqualsIgnoreCase {'ServicePrincipal', 'Application', 'User'}
@@ -17,7 +17,7 @@ AND
  )
  OR 
  (
-  @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1, 4d97b98b-1d4f-4787-a291-c67834d212e7, befefa01-2a29-4197-83a8-272ff33ce314, acdd72a7-3385-48ef-bd42-f606fba81ae7, ba92f5b4-2d11-453d-a403-e96b0029c9fe, 0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8, 4abbcc35-e782-43d8-92c5-2d3f1bd2253f, acdd72a7-3385-48ef-bd42-f606fba81ae7, b7e6dc6d-f1e8-4753-8033-0f276bb0955b,
+  @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1, 4d97b98b-1d4f-4787-a291-c67834d212e7, befefa01-2a29-4197-83a8-272ff33ce314, acdd72a7-3385-48ef-bd42-f606fba81ae7, ba92f5b4-2d11-453d-a403-e96b0029c9fe, 0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8, 4abbcc35-e782-43d8-92c5-2d3f1bd2253f, acdd72a7-3385-48ef-bd42-f606fba81ae7, b7e6dc6d-f1e8-4753-8033-0f276bb0955b, b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b,
   ${role_definition_id}}
   AND
   @Resource[Microsoft.Authorization/roleAssignments:PrincipalType] ForAnyOfAnyValues:StringEqualsIgnoreCase {'ServicePrincipal', 'Application', 'User'}


### PR DESCRIPTION
## Summary

Adds "Azure Kubernetes Service RBAC Cluster Admin" (role ID `b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b`) to the ABAC condition on the vendor-access "Role Based Access Control Administrator" role assignment.

This is required for the `enable_local_accounts=false` feature in `terraform-azurerm-cloud`. When local accounts are disabled on an AKS cluster, Azure RBAC is used for K8s authorization. The Terraform SP needs to assign itself "Azure Kubernetes Service RBAC Cluster Admin" during `terraform apply` so it can manage K8s resources in subsequent bootstrap steps. Without this role in the ABAC allowlist, that assignment fails with `Authorization_RequestDenied`.

## Why ABAC?

The customer grants the automation SP "Role Based Access Control Administrator" with an ABAC condition that restricts which roles it can assign — preventing the SP from granting itself arbitrary permissions. The allowlist already includes AKS cluster admin/user roles; this change adds the one additional role needed for Azure-RBAC-enabled clusters.

## Impact on Existing Customers

This is additive — the ABAC condition only gains a new allowed role, no existing permissions are removed. Existing customers who want to use `enable_local_accounts=false` will need to re-run `terraform apply` on their `terraform-managed-cloud` vendor-access module to pick up the updated condition. Customers not using this feature are unaffected.

## Related

- `terraform-azurerm-cloud` PR: streamnative/terraform-azurerm-cloud#71 (adds `enable_local_accounts` variable and the role assignment resource that requires this permission)

## Test Plan

- [x] Applied updated ABAC condition to test subscription `533d34c1-8210-4979-837d-5223b800c47e` via `az rest` PUT
- [x] Full end-to-end CE provisioning with `enable_local_accounts=false` succeeded — role assignment no longer hits `Authorization_RequestDenied`